### PR TITLE
Bugs fixed : sometimes the templates set in the setting would not be applied

### DIFF
--- a/src/Overrides/EmailConfirmationMailer.php
+++ b/src/Overrides/EmailConfirmationMailer.php
@@ -28,6 +28,13 @@ class EmailConfirmationMailer extends \Flarum\User\EmailConfirmationMailer
             $file = preg_grep('~^forum-.*\.css$~', scandir($this->assets_dir));
         }
 
+        if ($this->settings->get('fof-pretty-mail.mailhtml') !== file_get_contents(__DIR__.'/../../resources/views/emails/default.blade.php')) {
+            file_put_contents(
+                __DIR__.'/../../resources/views/emails/default.blade.php',
+                $this->settings->get('fof-pretty-mail.mailhtml')
+            );
+        }
+
         $this->mailer->send('pretty-mail::emails.default', [
             'body'       => $body,
             'settings'   => $this->settings,

--- a/src/Overrides/NotificationMailer.php
+++ b/src/Overrides/NotificationMailer.php
@@ -49,7 +49,7 @@ class NotificationMailer extends \Flarum\Notification\NotificationMailer
 
         if ($this->settings->get('fof-pretty-mail.'.$blade[1]) !== file_get_contents(__DIR__.'/../../resources/views/emails/'.$blade[1].'.blade.php')) {
             file_put_contents(
-                __DIR__.'/../../../resources/views/emails/'.$blade[1].'.blade.php',
+                __DIR__.'/../../resources/views/emails/'.$blade[1].'.blade.php',
                 $this->settings->get('fof-pretty-mail.'.$blade[1])
             );
         }


### PR DESCRIPTION
- When the first e-mail that is sent after enabling Pretty Mail is an "EmailConfirmation" (when a user changes his email address) then the default template set up in the admin pane would not be used. 

- The Notification e-mails would not replace the right file contents if a custom template was set up in the admin pane (the file path was wrong).