### PR TITLE
Fixed bug where sender of emails would be NULL.

### DIFF
--- a/src/Providers/MailerProvider.php
+++ b/src/Providers/MailerProvider.php
@@ -14,6 +14,7 @@ namespace FoF\PrettyMail\Providers;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Application;
 use Flarum\Notification\NotificationMailer;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\EmailConfirmationMailer;
 use FoF\PrettyMail\Mailer;
 use FoF\PrettyMail\Overrides;
@@ -32,10 +33,8 @@ class MailerProvider extends AbstractServiceProvider
                 $mailer->setQueue($app['queue']);
             }
 
-            $from = $app['config']['mail.from'];
-            if (is_array($from) && isset($from['address'])) {
-                $mailer->alwaysFrom($from['address'], $from['name']);
-            }
+            $settings = $app->make(SettingsRepositoryInterface::class);
+            $mailer->alwaysFrom($settings->get('mail_from'), $settings->get('forum_title'));
 
             return $mailer;
         });


### PR DESCRIPTION
This is a fix for the following Exception : 
```Swift_TransportException: Cannot send message without a sender address```
[As reported on the Flarum Community](https://discuss.flarum.org/d/11178-friendsofflarum-pretty-mail/41) there was an exception thrown when unsig pretty-mail with SMTP. 