### PR TITLE
beta 16 - Laravel 8 fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^0.1.0-beta.15"
+        "flarum/core": "^0.1.0-beta.16"
     },
     "replace": {
         "reflar/pretty-mail": "*"

--- a/src/Providers/MailerProvider.php
+++ b/src/Providers/MailerProvider.php
@@ -3,10 +3,11 @@
 /*
  * This file is part of fof/pretty-mail.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
  */
 
 namespace FoF\PrettyMail\Providers;
@@ -26,7 +27,7 @@ class MailerProvider extends AbstractServiceProvider
         $this->app->singleton('mailer', function (Container $container) {
             $view = $container['view'];
 
-            $mailer = new Mailer($view, $container['swift.mailer'], $container['events']);
+            $mailer = new Mailer('mailer', $view, $container['swift.mailer'], $container['events']);
 
             if ($container->bound('queue')) {
                 $mailer->setQueue($container['queue']);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #12** for Beta 16

**Changes proposed in this pull request:**
Instead of implementing mailer ourselves, this change updates to use Laravel 8.x mailmanager, and get a modified mailer instance from it.

**Reviewers should focus on:**
THere was previously a custom fof `Mailer.php` that extended laravel's Mailer.  Please confirm we're properly registering that instance in the manager to return later.

**Screenshot**
<img width="467" alt="Screen Shot 2021-04-14 at 2 43 32 PM" src="https://user-images.githubusercontent.com/5262154/114762491-d3f4ed80-9d2f-11eb-9737-7684c968a20a.png">


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

hmm
```
 composer test

                                                                  
  [Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "test" is not defined. 
```
